### PR TITLE
chore(ci): npm run checkの代わりにnpm run buildを使う

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,10 +21,9 @@ jobs:
           node-version: 22.x
           cache: "npm"
       - run: npm clean-install
-      - run: npm run check
+      - run: npm run build
       - run: npm run format
       - name: autofix.ci
         uses: autofix-ci/action@v1
         with:
           fail-fast: true
-          


### PR DESCRIPTION
checkでビルドエラーを検出できていなかったので