### PR TITLE
Raymee/groups

### DIFF
--- a/src/components/GroupDetailBox.astro
+++ b/src/components/GroupDetailBox.astro
@@ -34,7 +34,7 @@ const { title, imageSrc, imageAlt = "", paragraphs } = Astro.props;
 	.group-detail-box__title {
 		grid-column: 1 / 2;
 		margin-bottom: -1rem;
-		margin-left: 1.4rem;
+		margin-left: 0rem;
 		display: flex;
 		align-items: center;
 		gap: 0.5em;

--- a/src/components/GroupDetailBox.astro
+++ b/src/components/GroupDetailBox.astro
@@ -1,0 +1,103 @@
+---
+interface Props {
+	title: string;
+	imageSrc: string;
+	imageAlt?: string;
+	paragraphs: string[];
+}
+
+const { title, imageSrc, imageAlt = "", paragraphs } = Astro.props;
+---
+
+<section class="group-detail-box">
+	<div class="group-detail-box__title font-hakushu relative z-10 text-left text-3xl tracking-[0.2em] sm:text-4xl">{title}</div>
+
+	<div class="group-detail-box__image-area">
+		<img src={imageSrc} alt={imageAlt} class="group-detail-box__image" loading="lazy" />
+	</div>
+
+	<div class="group-detail-box__text-area">
+		{paragraphs.map((paragraph) => <p>{paragraph}</p>)}
+	</div>
+</section>
+
+<style>
+	.group-detail-box {
+		width: 80%;
+		margin: 2rem auto;
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 2.5rem;
+		align-items: stretch;
+	}
+
+	.group-detail-box__title {
+		grid-column: 1 / 2;
+		margin-bottom: -1rem;
+		margin-left: 1.4rem;
+		display: flex;
+		align-items: center;
+		gap: 0.5em;
+	}
+
+	.group-detail-box__title::before {
+		content: "";
+		display: inline-block;
+		width: 0.4em;
+		height: 1.1em;
+		background-color: currentColor;
+		flex-shrink: 0;
+	}
+
+	.group-detail-box__image-area {
+		grid-column: 2 / 3;
+		grid-row: 2;
+		width: 100%;
+	}
+
+	.group-detail-box__image {
+		display: block;
+		width: 100%;
+		aspect-ratio: 2 / 1;
+		object-fit: contain;
+		object-position: center;
+	}
+
+	.group-detail-box__text-area {
+		grid-column: 1 / 2;
+		grid-row: 2;
+		align-self: stretch;
+	}
+
+	.group-detail-box__text-area p {
+		margin: 0;
+		line-height: 1.8;
+	}
+
+	.group-detail-box__text-area p + p {
+		margin-top: 1rem;
+	}
+
+	@media (max-width: 768px) {
+		.group-detail-box {
+			width: 90%;
+			margin: 1.5rem auto;
+			grid-template-columns: 1fr;
+			gap: 1.5rem;
+		}
+
+		.group-detail-box__title {
+			font-size: 1.5rem;
+		}
+
+		.group-detail-box__image-area {
+			grid-column: auto;
+			grid-row: auto;
+		}
+
+		.group-detail-box__text-area {
+			grid-column: auto;
+			grid-row: auto;
+		}
+	}
+</style>

--- a/src/pages/groups/sample.astro
+++ b/src/pages/groups/sample.astro
@@ -1,9 +1,39 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 import Title from "../../components/layout/Title.astro";
+import GroupDetailBox from "../../components/GroupDetailBox.astro";
 import introDuctImage from "../../assets/Webp/groups/タイトル画像.webp";
 ---
 
 <Layout title="縁日班" description="高三特別班の縁日班を紹介する">
-    <Title heroImage={introDuctImage.src} title="縁日班" />
+  <Title heroImage={introDuctImage.src} title="縁日班" />
+  <GroupDetailBox
+    title="使命"
+    imageSrc={introDuctImage.src}
+    imageAlt="縁日班のイメージ画像"
+    paragraphs={[
+      "縁日班は、文化祭での模擬店を担当する特別班です。毎年、様々な種類の模擬店を企画・運営し、来場者に楽しんでもらえるよう努めています。",
+      "この班では、模擬店の企画から材料の調達、当日の運営までを行います。メンバーは協力してアイデアを出し合い、楽しいお店を作り上げることが求められます。",
+      "文化祭当日は、多くの来場者が訪れるため、忙しいですが、その分やりがいも大きいです。縁日班での経験は、チームワークや企画力を養う良い機会となります。",
+    ]}
+  />
+
+  <GroupDetailBox
+    title="価値観"
+    imageSrc={introDuctImage.src}
+    imageAlt="縁日班のイメージ画像"
+    paragraphs={[
+        "縁日班の価値観は、楽しさと協力です。私たちは、来場者に楽しんでもらうことを最優先に考えています。そのためには、メンバー同士が協力し合い、アイデアを出し合うことが重要です。",
+        "また、縁日班では、創造性も大切にしています。毎年新しい模擬店を企画するためには、独創的なアイデアが必要です。私たちは、自由な発想を歓迎し、メンバーが自分のアイデアを形にできるようサポートします。",
+    ]}
+  />
+  <GroupDetailBox
+    title="事業"
+    imageSrc={introDuctImage.src}
+    imageAlt="縁日班のイメージ画像"
+    paragraphs={[
+        "縁日班の主な活動内容は、模擬店の企画・運営です。毎年、文化祭のテーマに合わせた模擬店を企画し、材料の調達や当日の運営を行います。",
+        "また、文化祭前には、模擬店の準備や練習も行います。これには、メニューの試作や販売方法の練習などが含まれます。文化祭当日は、多くの来場者が訪れるため、忙しいですが、その分やりがいも大きいです。",
+    ]}
+    />
 </Layout>

--- a/src/pages/groups/sample.astro
+++ b/src/pages/groups/sample.astro
@@ -1,0 +1,9 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import Title from "../../components/layout/Title.astro";
+import introDuctImage from "../../assets/Webp/groups/タイトル画像.webp";
+---
+
+<Layout title="縁日班" description="高三特別班の縁日班を紹介する">
+    <Title heroImage={introDuctImage.src} title="縁日班" />
+</Layout>


### PR DESCRIPTION
This pull request introduces a new reusable `GroupDetailBox` component and applies it to the `sample.astro` group page to improve maintainability and consistency in how group details are displayed. The main changes are the creation and styling of the new component, and refactoring the sample group page to use it for structured content.

Component creation and styling:

* Added a new `GroupDetailBox.astro` component that accepts a title, image, alt text, and an array of paragraphs, and displays them in a responsive, styled layout. Includes custom CSS for desktop and mobile layouts.

Page refactor to use new component:

* Updated `sample.astro` to import and use the new `GroupDetailBox` component for each section ("使命", "価値観", "事業"), passing in relevant titles, images, and content as props. This improves code readability and reusability.