### PR TITLE
Raymee/box animation

### DIFF
--- a/src/components/GeneralBox.astro
+++ b/src/components/GeneralBox.astro
@@ -5,12 +5,14 @@ interface GeneralBoxImage {
   src: GeneralBoxImageSource;
   alt?: string;
   class?: string;
+  middleText?: string;
 }
 
 interface Props {
   topText?: string;
   bottomText?: string;
   middleText?: string;
+  middleTexts?: string[];
   detailHref?: string;
   containerClass?: string;
   images?: GeneralBoxImage[];
@@ -21,6 +23,7 @@ const {
   topText = "",
   bottomText = "",
   middleText = "",
+  middleTexts = [],
   detailHref = "#",
   containerClass = "",
   images = [],
@@ -30,14 +33,18 @@ const {
 const getImageSrc = (src: GeneralBoxImageSource) =>
   typeof src === "string" ? src : src.src;
 const carouselImages = images
-  .map((image) => ({
+  .map((image, index) => ({
     ...image,
     src: getImageSrc(image.src),
+    middleText: image.middleText ?? middleTexts[index] ?? middleText,
   }))
   .filter((image) => image.src)
   .slice(0, 4);
 const imageCount = carouselImages.length;
 const hasCarousel = imageCount > 0;
+const carouselMiddleTexts = carouselImages.map(
+  (image) => image.middleText ?? "",
+);
 const safeIntervalSeconds = Math.max(1.5, imageIntervalSeconds);
 ---
 
@@ -88,11 +95,26 @@ const safeIntervalSeconds = Math.max(1.5, imageIntervalSeconds);
       <p class="min-h-[1.5em] text-base leading-relaxed text-black sm:text-lg">
         {topText}
       </p>
-      <p
-        class="min-h-[1.5em] text-2xl leading-tight text-black sm:text-3xl md:text-4xl"
-      >
-        {middleText || "\u00A0"}
-      </p>
+      {
+        hasCarousel ? (
+          <div class="general-box-middle-texts min-h-[1.5em]">
+            {carouselMiddleTexts.map((text, index) => (
+              <p
+                class="general-box-middle-text text-2xl leading-tight text-black sm:text-3xl md:text-4xl"
+                aria-hidden={index === 0 ? "false" : "true"}
+                data-active={index === 0 ? "true" : "false"}
+                data-carousel-middle-text
+              >
+                {text || "\u00A0"}
+              </p>
+            ))}
+          </div>
+        ) : (
+          <p class="min-h-[1.5em] text-2xl leading-tight text-black sm:text-3xl md:text-4xl">
+            {middleText || "\u00A0"}
+          </p>
+        )
+      }
       <a
         href={detailHref}
         class="inline-flex w-fit items-center justify-center text-base leading-none text-white no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black"
@@ -146,6 +168,11 @@ const safeIntervalSeconds = Math.max(1.5, imageIntervalSeconds);
         .closest(".general-box-root")
         ?.querySelectorAll<HTMLElement>("[data-carousel-bar]") ?? [],
     );
+    const middleTexts = Array.from(
+      carousel
+        .closest(".general-box-root")
+        ?.querySelectorAll<HTMLElement>("[data-carousel-middle-text]") ?? [],
+    );
     const interval = Number(carousel.dataset.imageInterval) || 4000;
 
     if (images.length <= 1) {
@@ -163,6 +190,10 @@ const safeIntervalSeconds = Math.max(1.5, imageIntervalSeconds);
       images[previousIndex]?.setAttribute("data-leaving", "true");
       images[activeIndex]?.setAttribute("data-active", "true");
       images[activeIndex]?.setAttribute("aria-hidden", "false");
+      middleTexts[previousIndex]?.setAttribute("data-active", "false");
+      middleTexts[previousIndex]?.setAttribute("aria-hidden", "true");
+      middleTexts[activeIndex]?.setAttribute("data-active", "true");
+      middleTexts[activeIndex]?.setAttribute("aria-hidden", "false");
 
       bars.forEach((bar, index) => {
         bar.setAttribute(
@@ -214,6 +245,20 @@ const safeIntervalSeconds = Math.max(1.5, imageIntervalSeconds);
     z-index: 1;
   }
 
+  .general-box-middle-texts {
+    display: grid;
+  }
+
+  .general-box-middle-text {
+    grid-area: 1 / 1;
+    opacity: 0;
+    transition: opacity 500ms ease;
+  }
+
+  .general-box-middle-text[data-active="true"] {
+    opacity: 1;
+  }
+
   .general-box-bar {
     background-color: rgb(82 82 82);
     height: 1px;
@@ -237,6 +282,7 @@ const safeIntervalSeconds = Math.max(1.5, imageIntervalSeconds);
 
   @media (prefers-reduced-motion: reduce) {
     .general-box-carousel-image,
+    .general-box-middle-text,
     .general-box-bar {
       transition: none;
     }

--- a/src/components/GeneralBox.astro
+++ b/src/components/GeneralBox.astro
@@ -1,10 +1,18 @@
 ---
+interface GeneralBoxImage {
+  src: string;
+  alt?: string;
+  class?: string;
+}
+
 interface Props {
   topText?: string;
   bottomText?: string;
   middleText?: string;
   detailHref?: string;
   containerClass?: string;
+  images?: GeneralBoxImage[];
+  imageIntervalSeconds?: number;
 }
 
 const {
@@ -13,30 +21,54 @@ const {
   middleText = "",
   detailHref = "#",
   containerClass = "",
+  images = [],
+  imageIntervalSeconds = 4,
 } = Astro.props;
+
+const carouselImages = images.filter((image) => image.src).slice(0, 4);
+const imageCount = carouselImages.length;
+const hasCarousel = imageCount > 0;
+const safeIntervalSeconds = Math.max(1.5, imageIntervalSeconds);
 ---
 
 <div
-  class={`mx-auto w-full max-w-7xl py-4 px-8 sm:py-6 lg:px-16 ${containerClass}`}
+  class={`general-box-root mx-auto w-full max-w-7xl py-4 px-8 sm:py-6 lg:px-16 ${containerClass}`}
 >
   <div
     class="flex w-full flex-col overflow-hidden bg-white text-black md:aspect-5/2 md:flex-row"
   >
     <div
-      class="flex min-h-56 w-full items-center justify-center bg-neutral-800 md:min-h-0 md:w-3/5"
+      class="general-box-image-frame flex min-h-56 w-full items-center justify-center bg-neutral-800 md:min-h-0 md:w-3/5"
+      data-general-box-carousel={hasCarousel ? "true" : undefined}
+      data-image-count={hasCarousel ? imageCount : undefined}
+      data-image-interval={hasCarousel ? safeIntervalSeconds * 1000 : undefined}
     >
-      <slot name="image">
-        <div
-          aria-hidden="true"
-          class="flex h-full w-full items-center justify-center"
-        >
-          <span
-            class="font-hakushu text-[clamp(1.5rem,4vw,2.5rem)] text-slate-300"
-          >
-            準備中
-          </span>
-        </div>
-      </slot>
+      {
+        hasCarousel ? (
+          <div class="general-box-carousel h-full w-full">
+            {carouselImages.map((image, index) => (
+              <img
+                src={image.src}
+                alt={image.alt ?? ""}
+                class={`general-box-carousel-image box-border h-full w-full object-contain ${image.class ?? ""}`}
+                data-carousel-image
+                data-active={index === 0 ? "true" : "false"}
+              />
+            ))}
+          </div>
+        ) : (
+          <slot name="image">
+            <div
+              aria-hidden="true"
+              class="flex h-full w-full items-center justify-center"
+            >
+              <span class="font-hakushu text-[clamp(1.5rem,4vw,2.5rem)] text-slate-300">
+                準備中
+              </span>
+            </div>
+          </slot>
+        )
+      }
     </div>
 
     <div
@@ -60,12 +92,142 @@ const {
           {bottomText}
         </span>
       </a>
-      <div class="mt-4 flex gap-2 sm:gap-3 md:mx-4 md:mt-8">
-        <span class="block h-px w-12 bg-black sm:w-16 md:w-20"></span>
-        <span class="block h-px w-12 bg-neutral-600 sm:w-16 md:w-20"></span>
-        <span class="block h-px w-12 bg-neutral-600 sm:w-16 md:w-20"></span>
-        <span class="block h-px w-12 bg-neutral-600 sm:w-16 md:w-20"></span>
-      </div>
+      {
+        hasCarousel ? (
+          <div
+            class="general-box-bars mt-4 flex gap-2 sm:gap-3 md:mx-4 md:mt-8"
+            data-general-box-bars="true"
+            data-image-count={imageCount}
+          >
+            {Array.from({ length: 4 }).map((_, index) => (
+              <span
+                class="general-box-bar block w-12 sm:w-16 md:w-20"
+                data-carousel-bar={index}
+                data-active={index === 0 ? "true" : "false"}
+                data-empty={index >= imageCount ? "true" : "false"}
+              />
+            ))}
+          </div>
+        ) : (
+          <div class="mt-4 flex gap-2 sm:gap-3 md:mx-4 md:mt-8">
+            <span class="block h-px w-12 bg-black sm:w-16 md:w-20" />
+            <span class="block h-px w-12 bg-neutral-600 sm:w-16 md:w-20" />
+            <span class="block h-px w-12 bg-neutral-600 sm:w-16 md:w-20" />
+            <span class="block h-px w-12 bg-neutral-600 sm:w-16 md:w-20" />
+          </div>
+        )
+      }
     </div>
   </div>
 </div>
+
+<script>
+  const carousels = document.querySelectorAll<HTMLElement>(
+    "[data-general-box-carousel='true']",
+  );
+
+  carousels.forEach((carousel) => {
+    const images = Array.from(
+      carousel.querySelectorAll<HTMLElement>("[data-carousel-image]"),
+    );
+    const bars = Array.from(
+      carousel
+        .closest(".general-box-root")
+        ?.querySelectorAll<HTMLElement>("[data-carousel-bar]") ?? [],
+    );
+    const interval = Number(carousel.dataset.imageInterval) || 4000;
+
+    if (images.length <= 1) {
+      return;
+    }
+
+    let activeIndex = 0;
+
+    window.setInterval(() => {
+      const previousIndex = activeIndex;
+      activeIndex = (activeIndex + 1) % images.length;
+
+      images[previousIndex]?.setAttribute("data-active", "false");
+      images[previousIndex]?.setAttribute("data-leaving", "true");
+      images[activeIndex]?.setAttribute("data-active", "true");
+
+      bars.forEach((bar, index) => {
+        bar.setAttribute(
+          "data-active",
+          index === activeIndex ? "true" : "false",
+        );
+      });
+
+      window.setTimeout(() => {
+        images[previousIndex]?.removeAttribute("data-leaving");
+      }, 800);
+    }, interval);
+  });
+</script>
+
+<style>
+  .general-box-root {
+    isolation: isolate;
+  }
+
+  .general-box-image-frame {
+    position: relative;
+  }
+
+  .general-box-carousel {
+    position: relative;
+    overflow: hidden;
+  }
+
+  .general-box-carousel-image {
+    inset: 0;
+    opacity: 0;
+    position: absolute;
+    transform: translateX(100%);
+    transition:
+      opacity 800ms ease,
+      transform 800ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .general-box-carousel-image[data-active="true"] {
+    opacity: 1;
+    transform: translateX(0);
+    z-index: 2;
+  }
+
+  .general-box-carousel-image[data-leaving="true"] {
+    opacity: 0;
+    transform: translateX(-100%);
+    z-index: 1;
+  }
+
+  .general-box-bar {
+    background-color: rgb(82 82 82);
+    height: 1px;
+    opacity: 0.75;
+    transform-origin: left center;
+    transition:
+      background-color 500ms ease,
+      height 500ms ease,
+      opacity 500ms ease,
+      transform 500ms ease;
+  }
+
+  .general-box-bar[data-active="true"] {
+    background-color: rgb(0 0 0);
+    height: 4px;
+    opacity: 1;
+    transform: scaleX(1.08);
+  }
+
+  .general-box-bar[data-empty="true"] {
+    opacity: 0.25;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .general-box-carousel-image,
+    .general-box-bar {
+      transition: none;
+    }
+  }
+</style>

--- a/src/components/GeneralBox.astro
+++ b/src/components/GeneralBox.astro
@@ -51,6 +51,7 @@ const safeIntervalSeconds = Math.max(1.5, imageIntervalSeconds);
                 src={image.src}
                 alt={image.alt ?? ""}
                 class={`general-box-carousel-image box-border h-full w-full object-contain ${image.class ?? ""}`}
+                aria-hidden={index === 0 ? "false" : "true"}
                 data-carousel-image
                 data-active={index === 0 ? "true" : "false"}
               />
@@ -148,8 +149,10 @@ const safeIntervalSeconds = Math.max(1.5, imageIntervalSeconds);
       activeIndex = (activeIndex + 1) % images.length;
 
       images[previousIndex]?.setAttribute("data-active", "false");
+      images[previousIndex]?.setAttribute("aria-hidden", "true");
       images[previousIndex]?.setAttribute("data-leaving", "true");
       images[activeIndex]?.setAttribute("data-active", "true");
+      images[activeIndex]?.setAttribute("aria-hidden", "false");
 
       bars.forEach((bar, index) => {
         bar.setAttribute(
@@ -205,19 +208,17 @@ const safeIntervalSeconds = Math.max(1.5, imageIntervalSeconds);
     background-color: rgb(82 82 82);
     height: 1px;
     opacity: 0.75;
-    transform-origin: left center;
+    transform-origin: center center;
     transition:
       background-color 500ms ease,
-      height 500ms ease,
       opacity 500ms ease,
       transform 500ms ease;
   }
 
   .general-box-bar[data-active="true"] {
     background-color: rgb(0 0 0);
-    height: 4px;
     opacity: 1;
-    transform: scaleX(1.08);
+    transform: scale(1.08, 4);
   }
 
   .general-box-bar[data-empty="true"] {

--- a/src/components/GeneralBox.astro
+++ b/src/components/GeneralBox.astro
@@ -1,6 +1,8 @@
 ---
+type GeneralBoxImageSource = string | { src: string };
+
 interface GeneralBoxImage {
-  src: string;
+  src: GeneralBoxImageSource;
   alt?: string;
   class?: string;
 }
@@ -25,7 +27,15 @@ const {
   imageIntervalSeconds = 4,
 } = Astro.props;
 
-const carouselImages = images.filter((image) => image.src).slice(0, 4);
+const getImageSrc = (src: GeneralBoxImageSource) =>
+  typeof src === "string" ? src : src.src;
+const carouselImages = images
+  .map((image) => ({
+    ...image,
+    src: getImageSrc(image.src),
+  }))
+  .filter((image) => image.src)
+  .slice(0, 4);
 const imageCount = carouselImages.length;
 const hasCarousel = imageCount > 0;
 const safeIntervalSeconds = Math.max(1.5, imageIntervalSeconds);

--- a/src/components/GroupIntroBox.astro
+++ b/src/components/GroupIntroBox.astro
@@ -1,12 +1,20 @@
 ---
+interface GroupIntroImage {
+  src: string;
+  alt?: string;
+  class?: string;
+}
+
 interface Props {
   imageSrc?: string;
   imageAlt?: string;
   imageClass?: string;
+  images?: GroupIntroImage[];
   topText?: string;
   bottomText?: string;
   middleText?: string;
   detailHref?: string;
+  imageIntervalSeconds?: number;
 }
 
 import GeneralBox from "./GeneralBox.astro";
@@ -18,12 +26,19 @@ const {
   imageSrc = "",
   imageAlt = "",
   imageClass = "",
+  images = [],
   topText = TOP_TEXT,
   bottomText = BOTTOM_TEXT,
   middleText = "",
   detailHref = "#",
+  imageIntervalSeconds = 4,
 } = Astro.props;
+
 const imageClassName = `box-border h-full w-full object-contain ${imageClass}`;
+const carouselImages = images.map((image) => ({
+  ...image,
+  class: `object-contain ${imageClass} ${image.class ?? ""}`,
+}));
 ---
 
 <GeneralBox
@@ -31,20 +46,28 @@ const imageClassName = `box-border h-full w-full object-contain ${imageClass}`;
   bottomText={bottomText}
   middleText={middleText}
   detailHref={detailHref}
+  images={carouselImages}
+  imageIntervalSeconds={imageIntervalSeconds}
 >
   {
-    imageSrc ? (
-      <img slot="image" src={imageSrc} alt={imageAlt} class={imageClassName} />
-    ) : (
-      <div
-        slot="image"
-        aria-hidden="true"
-        class="flex h-full w-full items-center justify-center"
-      >
-        <span class="font-hakushu text-[clamp(1.5rem,4vw,2.5rem)] text-slate-300">
-          準備中
-        </span>
-      </div>
-    )
+    carouselImages.length === 0 &&
+      (imageSrc ? (
+        <img
+          slot="image"
+          src={imageSrc}
+          alt={imageAlt}
+          class={imageClassName}
+        />
+      ) : (
+        <div
+          slot="image"
+          aria-hidden="true"
+          class="flex h-full w-full items-center justify-center"
+        >
+          <span class="font-hakushu text-[clamp(1.5rem,4vw,2.5rem)] text-slate-300">
+            準備中
+          </span>
+        </div>
+      ))
   }
 </GeneralBox>

--- a/src/components/GroupIntroBox.astro
+++ b/src/components/GroupIntroBox.astro
@@ -1,6 +1,8 @@
 ---
+type GroupIntroImageSource = string | { src: string };
+
 interface GroupIntroImage {
-  src: string;
+  src: GroupIntroImageSource;
   alt?: string;
   class?: string;
 }

--- a/src/components/GroupIntroBox.astro
+++ b/src/components/GroupIntroBox.astro
@@ -5,6 +5,7 @@ interface GroupIntroImage {
   src: GroupIntroImageSource;
   alt?: string;
   class?: string;
+  middleText?: string;
 }
 
 interface Props {
@@ -15,6 +16,7 @@ interface Props {
   topText?: string;
   bottomText?: string;
   middleText?: string;
+  middleTexts?: string[];
   detailHref?: string;
   imageIntervalSeconds?: number;
 }
@@ -32,6 +34,7 @@ const {
   topText = TOP_TEXT,
   bottomText = BOTTOM_TEXT,
   middleText = "",
+  middleTexts = [],
   detailHref = "#",
   imageIntervalSeconds = 4,
 } = Astro.props;
@@ -47,6 +50,7 @@ const carouselImages = images.map((image) => ({
   topText={topText}
   bottomText={bottomText}
   middleText={middleText}
+  middleTexts={middleTexts}
   detailHref={detailHref}
   images={carouselImages}
   imageIntervalSeconds={imageIntervalSeconds}

--- a/src/pages/groups/index.astro
+++ b/src/pages/groups/index.astro
@@ -56,7 +56,7 @@ import shougaiImage from "../../assets/Webp/groups/特別班渉外事務局.webp
     imageAlt="渉外事務局のイメージ画像"
     imageClass="p-8 sm:p-12 md:p-16"
     middleText="渉外事務局"
-    detailHref="/groups/shougai"
+    detailHref="/groups/shogai"
   />
 
   <GroupIntroBox

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -114,17 +114,20 @@ const image = await getImage({ src: bgCircleImage, format: "svg" });
         detailHref="/groups/"
         images={[
           {
-            src: stageImage.src,
+            src: groupTitleImage.src,
             alt: "特別班紹介の画像1",
+            middleText: "各班紹介",
           },
           {
-            src: groupTitleImage.src,
+            src: stageImage.src,
             alt: "特別班紹介の画像2",
+            middleText: "ステージ班",
           },
           {
             src: shogaiOfficeImage.src,
             class: "p-8 sm:p-12 md:p-16",
             alt: "特別班紹介の画像3",
+            middleText: "渉外事務局",
           },
         ]}
       />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,9 @@ import ConceptLogoSvg from "../assets/SVG/concept_logo.svg";
 import Countdown from "../components/Countdown.astro";
 import LogoWithExternalAffairs from "../assets/SVG/logo_with_externalaffairs.svg";
 import GeneralBox from "../components/GeneralBox.astro";
+import stageImage from "../assets/Webp/groups/stageImage.webp";
+import groupTitleImage from "../assets/Webp/groups/タイトル画像.webp";
+import shogaiOfficeImage from "../assets/Webp/groups/特別班渉外事務局.webp";
 
 import { getImage } from "astro:assets";
 
@@ -109,6 +112,21 @@ const image = await getImage({ src: bgCircleImage, format: "svg" });
         middleText="特別班紹介"
         bottomText="詳細はこちら"
         detailHref="/groups/"
+        images={[
+          {
+            src: stageImage.src,
+            alt: "特別班紹介の画像1",
+          },
+          {
+            src: groupTitleImage.src,
+            alt: "特別班紹介の画像2",
+          },
+          {
+            src: shogaiOfficeImage.src,
+            class: "p-8 sm:p-12 md:p-16",
+            alt: "特別班紹介の画像3",
+          },
+        ]}
       />
     </div>
   </section>


### PR DESCRIPTION
このプルリクエストでは、`GeneralBox` コンポーネントと `GroupIntroBox` コンポーネントに画像カルーセル機能を追加し、複数の画像をスムーズなトランジションとナビゲーションバー付きで表示できるようにしました。さらに、ホームページを更新し、「特別班紹介」セクションで新しいカルーセル機能を利用するようにしました。また、グループ詳細リンクの軽微なタイプミスも修正しました。

**主な変更点:**

### コンポーネントのカルーセル機能

* `GeneralBox` と `GroupIntroBox` の両方に、`images` プロパティ（画像オブジェクトの配列）とオプションの `imageIntervalSeconds` プロパティのサポートを追加しました。これにより、最大4枚の画像を、設定可能な間隔でカルーセル表示できるようになりました。実装には、アニメーションによるトランジションと、現在表示中の画像を示すナビゲーションバーが含まれています。

### ホームページの改善

* ホームページの「特別班紹介」（`/groups/`）セクションを更新し、`GeneralBox`コンポーネントに画像配列を渡すことで、新しいカルーセルを使用するようにしました。これにより、より豊かな視覚体験を提供できるようになりました。 

### バグ修正

* グループ詳細リンクのスペルミスを修正しました。`/groups/shougai` から `/groups/shogai` に変更しました.。